### PR TITLE
chore: update GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,9 +33,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,15 +25,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/label-commenter.yml
+++ b/.github/workflows/label-commenter.yml
@@ -14,7 +14,7 @@ jobs:
   comment:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: main
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Validate version
@@ -46,9 +46,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Publish

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Set up Python 3.13
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
       - name: Build test coverage
@@ -33,7 +33,7 @@ jobs:
         run: make local
       - name: Upload test coverage
         if: ${{ !cancelled() }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./build/coverage


### PR DESCRIPTION
## Summary

Update GitHub Actions to versions compatible with Node 24:

| Action | Old Version | New Version |
|--------|-------------|-------------|
| `actions/checkout` | v2, v4 | v6 |
| `actions/setup-python` | v5 | v6 |
| `github/codeql-action/*` | v3 | v4 |
| `codecov/codecov-action` | v4 | v6 |

### Files Updated
- `.github/workflows/build.yml`
- `.github/workflows/codeql-analysis.yml`
- `.github/workflows/label-commenter.yml`
- `.github/workflows/release.yml`
- `.github/workflows/validate.yml`

## Test Plan
- [ ] Verify workflows pass on this PR
- [ ] Confirm CodeQL analysis runs successfully
- [ ] Confirm test coverage uploads to Codecov